### PR TITLE
correct artifactstagingdirectory variable. see https://docs.microsoft.com/en-us/azure/devops/pipelines/languages/dotnet-core?view=vsts&tabs=yaml#package-and-deliver-your-code

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ steps:
 - script: |
     dotnet build --configuration $(buildConfiguration)
     dotnet test dotnetcore-tests --configuration $(buildConfiguration) --logger trx
-    dotnet publish --configuration $(buildConfiguration) --output $BUILD_ARTIFACTSTAGINGDIRECTORY
+    dotnet publish --configuration $(buildConfiguration) --output $(Build.ArtifactStagingDirectory)
 
 - task: PublishTestResults@2
   inputs:


### PR DESCRIPTION
correct artifactstagingdirectory variable. see https://docs.microsoft.com/en-us/azure/devops/pipelines/languages/dotnet-core?view=vsts&tabs=yaml#package-and-deliver-your-code

Because the current `BUILD_ARTIFACTSTAGINGDIRECTORY` won't work on Azure DevOps Pipeline builds.

I have tried to use `BUILD_ARTIFACTSTAGINGDIRECTORY` and it failed. The correct variable name should be `Build.ArtifactStagingDirectory`.