### PR TITLE
Corrects build artifact staging directory for dotnet publish

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ steps:
 - script: |
     dotnet build --configuration $(buildConfiguration)
     dotnet test dotnetcore-tests --configuration $(buildConfiguration) --logger trx
-    dotnet publish --configuration $(buildConfiguration) --output $BUILD_ARTIFACTSTAGINGDIRECTORY
+    dotnet publish --configuration $(buildConfiguration) --output $(build.artifactstagingdirectory)
 
 - task: PublishTestResults@2
   condition: succeededOrFailed()


### PR DESCRIPTION
When testing this out, I found that the --output parameter on the dotnet publish command is incorrect. 