### PR TITLE
Updating azure-pipelines.yml - Using a .NET global tool, dotnetsay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ bld/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/
+.vscode/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,3 +12,4 @@ WORKDIR /app
 COPY dotnetcore-sample/out .
 
 ENTRYPOINT ["dotnet", "dotnetcore-sample.dll"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,16 @@
 # See http://docs.microsoft.com/azure/devops/pipelines/languages/docker for more information
 
 # Create a container with the compiled asp.net core app
+# This image is downloaded from here
 FROM microsoft/aspnetcore:2.0
+
+
 
 # Create app directory
 WORKDIR /app
 
 # Copy files from the artifact staging folder on agent
+# I can't create the artifact in a complete way ..
 COPY dotnetcore-sample/out .
 
 ENTRYPOINT ["dotnet", "dotnetcore-sample.dll"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /app
 
 # Copy files from the artifact staging folder on agent
 # I can't create the artifact in a complete way ..
-COPY dotnetcore-sample/out .
+# COPY dotnetcore-sample/out .
 
 ENTRYPOINT ["dotnet", "dotnetcore-sample.dll"]
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://dev.azure.com/bgarcia0366/pipelines-dotnet-core/_apis/build/status/bgarcial.pipelines-dotnet-core?branchName=master)](https://dev.azure.com/bgarcia0366/pipelines-dotnet-core/_build/latest?definitionId=3?branchName=master)
+
 # Sample ASP.NET Core application for Azure Pipelines docs
 
 For information on how to use this repository, see [.NET Core](https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core).

--- a/azure-pipelines.acr.yml
+++ b/azure-pipelines.acr.yml
@@ -7,8 +7,8 @@ variables:
   buildConfiguration: 'Release'
   imageName: 'dotnetcore:$(Build.BuildId)'
   # define two more variables dockerId and dockerPassword in the build pipeline in UI
-  dockerId: 'possibilITest'
-  dockerPassword: '6Rkdm=LJJZawnpwrMvun6TdAmOSAneAj'
+  dockerId: 'testing'
+  dockerPassword: 'my-password'
   
 steps:
 - script: |

--- a/azure-pipelines.acr.yml
+++ b/azure-pipelines.acr.yml
@@ -7,7 +7,9 @@ variables:
   buildConfiguration: 'Release'
   imageName: 'dotnetcore:$(Build.BuildId)'
   # define two more variables dockerId and dockerPassword in the build pipeline in UI
-
+  dockerId: 'possibilITest'
+  dockerPassword: '6Rkdm=LJJZawnpwrMvun6TdAmOSAneAj'
+  
 steps:
 - script: |
     dotnet build --configuration $(buildConfiguration)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -96,8 +96,8 @@ steps:
 
 
 # Build a docker image
-#- script: | 
-#    docker build -t $(dockerId)/$(imageName) .  # add options to this command to meet your needs 
+- script: | 
+    docker build -t $(dockerId)/$(imageName) .  # add options to this command to meet your needs 
 #    docker build -f Dockerfile -t $(dockerId).azurecr.io/$(imageName) .
 #    docker login -u $(dockerId) -p $pswd $(dockerid).azurecr.io
 #    docker push $(dockerId).azurecr.io/$(imageName)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,9 +18,9 @@ steps:
     # https://www.nuget.org/packages/dotnetsay/
     # dotnet tool install -g dotnetsay
     # dotnetsay
-    dotnet tool install --tool-path . dotnetsay
-    .\dotnetsay
-    displayName: 'Command Line Script'    
+    dotnet tool install  --tool-path . dotnetsay
+    ./dotnetsay
+  displayName: 'Command Line Script'    
 
 # .NET Core
 # Restore NuGet packages.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,10 @@ steps:
     # https://www.nuget.org/packages/dotnetsay/
     # dotnet tool install -g dotnetsay
     # dotnetsay
+    # Above in reference with dotnetsay command this is the original way about install it. But there is this bug
+    # https://developercommunity.visualstudio.com/content/problem/340067/install-global-tool.html?childToView=343864#comment-343864
+    # which was soleved with this comment issue https://github.com/dotnet/cli/issues/8368#issuecomment-424852996
+
     dotnet tool install  --tool-path . dotnetsay
     ./dotnetsay
   displayName: 'Command Line Script'    

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,3 +97,11 @@ steps:
     #publishFeedCredentials: 'pipelines-dotnet-core'
     #versioningScheme: byEnvVar
     #versionEnvVar: version
+
+# To create a .zip file archive that's ready for publishing to a web app, add the following snippet:
+- task: DotNetCoreCLI@2
+  inputs:
+    command: publish
+    publishWebProjects: True
+    arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)'
+    zipAfterPublish: True

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,10 +88,12 @@ steps:
 # To create and publish a NuGet package, add the following snippet:
 - script: dotnet pack /p:PackageVersion=$(version)  # define version variable elsewhere in your pipeline
 
-- task: NuGetCommand@2
-  inputs:
-    command: push
-    nuGetFeedType: external
-    publishFeedCredentials: 'pipelines-dotnet-core'
-    versioningScheme: byEnvVar
-    versionEnvVar: version
+
+# I have to get the creentials
+# - task: NuGetCommand@2
+#  inputs:
+    #command: push
+    #nuGetFeedType: external
+    #publishFeedCredentials: 'pipelines-dotnet-core'
+    #versioningScheme: byEnvVar
+    #versionEnvVar: version

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ steps:
 
 - task: DotNetCoreInstaller@0
   inputs:
-    version: '2.2.1' # replace this value with the version that you need for your project
+    version: '2.2.103' # replace this value with the version that you need for your project
 
 # Use the .NET Core task to run unit tests in your .NET Core solution by using testing frameworks like MSTest, xUnit, and NUnit. 
 # THere is a warning # #[warning]Project file(s) matching the specified pattern were not found. 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,3 +41,10 @@ steps:
     testResultsFiles: '**/*.trx'
 
 - task: PublishBuildArtifacts@1
+
+# Use the .NET Core task to run unit tests in your .NET Core solution by using testing frameworks like MSTest, xUnit, and NUnit. 
+- task: DotNetCoreCLI@2
+  inputs:
+    command: test
+    projects: '**/*Tests/*.csproj'
+    arguments: '--configuration $(buildConfiguration)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,8 +13,15 @@ variables:
   dockerId: 'possibilItest'
   dockerPassword: '6Rkdm=LJJZawnpwrMvun6TdAmOSAneAj'
 
+- task: DotNetCoreInstaller@0
+  inputs:
+    version: '2.1.300' # replace this value with the version that you need for your project
+
 steps:
 - script: |
+
+    # Restore dependences https://docs.microsoft.com/en-us/azure/devops/pipelines/languages/dotnet-core?view=vsts&tabs=yaml#restore-dependencies
+    dotnet restore
     dotnet build --configuration $(buildConfiguration) # Include additional options such as --configuration to meet your need
     dotnet test dotnetcore-tests --configuration $(buildConfiguration) --logger trx
     
@@ -32,21 +39,6 @@ steps:
     ./dotnetsay
   displayName: 'Command Line Script'    
 
-# .NET Core
-# Restore NuGet packages.
-- task: DotNetCoreCLI@2
-  inputs:
-    command: 'restore'
-    projects: '**/*.csproj'
-    #verbosityRestore: 'detailed' # Options: quiet, minimal, normal, detailed, diagnostic
-
-- task: PublishTestResults@2
-  condition: succeededOrFailed()
-  inputs:
-    testRunner: VSTest
-    testResultsFiles: '**/*.trx'
-
-- task: PublishBuildArtifacts@1
 
 # Use the .NET Core task to run unit tests in your .NET Core solution by using testing frameworks like MSTest, xUnit, and NUnit. 
 # THere is a warning # #[warning]Project file(s) matching the specified pattern were not found. 
@@ -65,56 +57,19 @@ steps:
     testRunner: VSTest
     testResultsFiles: '**/*.trx'
 
-# Collect code coverage
-# https://docs.microsoft.com/en-us/azure/devops/pipelines/languages/dotnet-core?view=vsts&tabs=yaml#collect-code-coverage
-- task: DotNetCoreCLI@2
-  inputs:
-    command: test
-    projects: '**/*Tests/*.csproj'
-    arguments: '--configuration $(buildConfiguration) --collect "Code coverage"'
 
-
-# If you choose to run the dotnet test command, 
-# specify the test results logger and coverage options. Then use the Publish Test Results task:
-- script: dotnet test dotnetcore-sample.sln --logger trx --collect "Code coverage"
-- task: PublishTestResults@2
-  inputs:
-    testRunner: VSTest
-    testResultsFiles: '**/*.trx'
-
-# Package and deliver the code 
-# https://docs.microsoft.com/en-us/azure/devops/pipelines/languages/dotnet-core?view=vsts&tabs=yaml#package-and-deliver-your-code
-# This code takes all the files in $(Build.ArtifactStagingDirectory) and upload them as 
-# an artifact of your build. 
-- task: PublishBuildArtifacts@1
-
-# Publish to a NuGet feed
-# To create and publish a NuGet package, add the following snippet:
-- script: dotnet pack /p:PackageVersion=$(version)  # define version variable elsewhere in your pipeline
-
-
-# I have to get the creentials
-# - task: NuGetCommand@2
+# .NET Core
+# Restore NuGet packages.
+#- task: DotNetCoreCLI@2
 #  inputs:
-    #command: push
-    #nuGetFeedType: external
-    #publishFeedCredentials: 'pipelines-dotnet-core'
-    #versioningScheme: byEnvVar
-    #versionEnvVar: version
+#    command: 'restore'
+#    projects: '**/*.csproj'
+    #verbosityRestore: 'detailed' # Options: quiet, minimal, normal, detailed, diagnostic
 
-# To create a .zip file archive that's ready for publishing to a web app, add the following snippet:
-- task: DotNetCoreCLI@2
-  inputs:
-    command: publish
-    publishWebProjects: True
-    arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)'
-    zipAfterPublish: True
 
-- task: AzureRmWebAppDeployment@3
-  inputs:
-    azureSubscription: 'Free trial'
-    WebAppName: 'dotnetcore'
-    Package: $(System.ArtifactsDirectory)/**/*.zip
+
+
+
 
 # Build a docker image
 #- script: | 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,9 @@ steps:
     # https://www.nuget.org/packages/dotnetsay/
     dotnet tool install -g dotnetsay
     # dotnetsay
-- script: dotnetsay
+
+- script: |
+    dotnetsay
 
 - task: PublishTestResults@2
   condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ steps:
     # You can run any dotnet command in your pipeline. The following example shows how to install and use a .NET global tool, dotnetsay:
     # https://www.nuget.org/packages/dotnetsay/
     dotnet tool install -g dotnetsay
-    dotnetsay
+    # dotnetsay
 
 - task: PublishTestResults@2
   condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,6 +98,10 @@ steps:
 # Build a docker image
 - script: | 
     docker build -t $(dockerId)/$(imageName) .  # add options to this command to meet your needs 
+    docker build -t $(dockerId).azurecr.io/$(imageName) .
+    docker login -u $(dockerId) -p $(pswd) $(dockerId).azurecr.io
+    docker push $(dockerId).azurecr.io/$(imageName)
+
 #    docker build -f Dockerfile -t $(dockerId).azurecr.io/$(imageName) .
 #    docker login -u $(dockerId) -p $pswd $(dockerid).azurecr.io
 #    docker push $(dockerId).azurecr.io/$(imageName)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,9 +13,6 @@ variables:
   dockerId: 'possibilItest'
   dockerPassword: '6Rkdm=LJJZawnpwrMvun6TdAmOSAneAj'
 
-- task: DotNetCoreInstaller@0
-  inputs:
-    version: '2.1.300' # replace this value with the version that you need for your project
 
 steps:
 - script: |
@@ -39,6 +36,10 @@ steps:
     ./dotnetsay
   displayName: 'Command Line Script'    
 
+
+- task: DotNetCoreInstaller@0
+  inputs:
+    version: '2.1.300' # replace this value with the version that you need for your project
 
 # Use the .NET Core task to run unit tests in your .NET Core solution by using testing frameworks like MSTest, xUnit, and NUnit. 
 # THere is a warning # #[warning]Project file(s) matching the specified pattern were not found. 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,10 @@ steps:
     # You can run any dotnet command in your pipeline. The following example shows how to install and use a .NET global tool, dotnetsay:
     # https://www.nuget.org/packages/dotnetsay/
     # dotnet tool install -g dotnetsay
-    # dotnetsay    
+    # dotnetsay
+    dotnet tool install --tool-path . dotnetsay
+    .\dotnetsay
+    displayName: 'Command Line Script'    
 
 # .NET Core
 # Restore NuGet packages.
@@ -26,10 +29,6 @@ steps:
     command: 'restore'
     projects: '**/*.csproj'
     #verbosityRestore: 'detailed' # Options: quiet, minimal, normal, detailed, diagnostic
-
-- script: dotnet tool install -g dotnetsay
-- script: dotnet dotnetsay
-
 
 - task: PublishTestResults@2
   condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -99,7 +99,7 @@ steps:
 - script: | 
     docker build -t $(dockerId)/$(imageName) .  # add options to this command to meet your needs 
     docker build -t $(dockerId).azurecr.io/$(imageName) .
-    docker login -u $(dockerId) -p $(pswd) $(dockerId).azurecr.io
+    docker login -u $(dockerId) -p $(dockerPassword) $(dockerId).azurecr.io
     docker push $(dockerId).azurecr.io/$(imageName)
 
 #    docker build -f Dockerfile -t $(dockerId).azurecr.io/$(imageName) .

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,6 +59,15 @@ steps:
     testResultsFiles: '**/*.trx'
 
 
+# Collect code coverage
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/languages/dotnet-core?view=vsts&tabs=yaml#collect-code-coverage
+- task: DotNetCoreCLI@2
+  inputs:
+    command: test
+    projects: '**/*Tests/*.csproj'
+    arguments: '--configuration $(buildConfiguration) --collect "Code coverage"'
+
+
 # .NET Core
 # Restore NuGet packages.
 #- task: DotNetCoreCLI@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ steps:
     dotnet test dotnetcore-tests --configuration $(buildConfiguration) --logger trx
     
     # Publishing the output of the build
-    dotnet publish --configuration $(buildConfiguration) --output $BUILD_ARTIFACTSTAGINGDIRECTORY
+    dotnet publish --configuration $(buildConfiguration) --output $(Build.ArtifactStagingDirectory)
     # You can run any dotnet command in your pipeline. The following example shows how to install and use a .NET global tool, dotnetsay:
     # https://www.nuget.org/packages/dotnetsay/
     # dotnet tool install -g dotnetsay
@@ -72,6 +72,8 @@ steps:
   inputs:
     testRunner: VSTest
     testResultsFiles: '**/*.trx'
+
+- task: PublishBuildArtifacts@1
 
 # .NET Core
 # Restore NuGet packages.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,7 @@ steps:
 
 # Use the .NET Core task to run unit tests in your .NET Core solution by using testing frameworks like MSTest, xUnit, and NUnit. 
 # THere is a warning # #[warning]Project file(s) matching the specified pattern were not found. 
-# https://stackoverflow.com/a/53053739/2773461
+# https://stackoverflow.com/a/53053739/2773461 I should check it in depth.
 - task: DotNetCoreCLI@2
   inputs:
     command: test
@@ -55,6 +55,23 @@ steps:
 - script: dotnet test dotnetcore-sample.sln --logger trx
 - task: PublishTestResults@2
   condition: succeededOrFailed()
+  inputs:
+    testRunner: VSTest
+    testResultsFiles: '**/*.trx'
+
+# Collect code coverage
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/languages/dotnet-core?view=vsts&tabs=yaml#collect-code-coverage
+- task: DotNetCoreCLI@2
+  inputs:
+    command: test
+    projects: '**/*Tests/*.csproj'
+    arguments: '--configuration $(buildConfiguration) --collect "Code coverage"'
+
+
+# If you choose to run the dotnet test command, 
+# specify the test results logger and coverage options. Then use the Publish Test Results task:
+- script: dotnet test dotnetcore-sample.sln --logger trx --collect "Code coverage"
+- task: PublishTestResults@2
   inputs:
     testRunner: VSTest
     testResultsFiles: '**/*.trx'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,4 +80,18 @@ steps:
 
 # Package and deliver the code 
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/languages/dotnet-core?view=vsts&tabs=yaml#package-and-deliver-your-code
+# This code takes all the files in $(Build.ArtifactStagingDirectory) and upload them as 
+# an artifact of your build. 
 - task: PublishBuildArtifacts@1
+
+# Publish to a NuGet feed
+# To create and publish a NuGet package, add the following snippet:
+- script: dotnet pack /p:PackageVersion=$(version)  # define version variable elsewhere in your pipeline
+
+- task: NuGetCommand@2
+  inputs:
+    command: push
+    nuGetFeedType: external
+    publishFeedCredentials: '<Name of the NuGet service connection>'
+    versioningScheme: byEnvVar
+    versionEnvVar: version

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,6 +8,10 @@ pool:
   
 variables:
   buildConfiguration: 'Release'
+  imageName: 'dotnetcore:$(Build.BuildId)'
+  # define two more variables dockerId and dockerPassword in the build pipeline in UI
+  dockerId: 'possibilITest'
+  dockerPassword: '6Rkdm=LJJZawnpwrMvun6TdAmOSAneAj'
 
 steps:
 - script: |
@@ -105,3 +109,10 @@ steps:
     publishWebProjects: True
     arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)'
     zipAfterPublish: True
+
+# Build a docker image
+- script: | 
+    docker build -t $(dockerId)/$(imageName) .  # add options to this command to meet your needs 
+    docker build -f Dockerfile -t $(dockerId).azurecr.io/$(imageName) .
+    docker login -u $(dockerId) -p $pswd $(dockerid).azurecr.io
+    docker push $(dockerId).azurecr.io/$(imageName)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,10 +11,14 @@ variables:
 
 steps:
 - script: |
-    dotnet build --configuration $(buildConfiguration)
+    dotnet build --configuration $(buildConfiguration) # Include additional options such as --configuration to meet your need
     dotnet test dotnetcore-tests --configuration $(buildConfiguration) --logger trx
     dotnet publish --configuration $(buildConfiguration) --output $BUILD_ARTIFACTSTAGINGDIRECTORY
     dotnet restore
+    # You can run any dotnet command in your pipeline. The following example shows how to install and use a .NET global tool, dotnetsay:
+    # https://www.nuget.org/packages/dotnetsay/
+    dotnet tool install -g dotnetsay
+    dotnetsay
 
 - task: PublishTestResults@2
   condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,6 +75,13 @@ steps:
 
 - task: PublishBuildArtifacts@1
 
+- task: DotNetCoreCLI@2
+  inputs:
+    command: publish
+    publishWebProjects: True
+    arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)'
+    zipAfterPublish: True
+
 # .NET Core
 # Restore NuGet packages.
 #- task: DotNetCoreCLI@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,8 +10,8 @@ variables:
   buildConfiguration: 'Release'
   imageName: 'dotnetcore:$(Build.BuildId)'
   # define two more variables dockerId and dockerPassword in the build pipeline in UI
-  dockerId: 'possibilItest'
-  dockerPassword: '6Rkdm=LJJZawnpwrMvun6TdAmOSAneAj'
+  dockerId: 'dotnetcoretesting'
+  dockerPassword: '/cV0=NHCUvKAY5RSKMMNy0i+Jpm6NaRn'
 
 
 steps:
@@ -39,7 +39,7 @@ steps:
 
 - task: DotNetCoreInstaller@0
   inputs:
-    version: '2.2' # replace this value with the version that you need for your project
+    version: '2.2.1' # replace this value with the version that you need for your project
 
 # Use the .NET Core task to run unit tests in your .NET Core solution by using testing frameworks like MSTest, xUnit, and NUnit. 
 # THere is a warning # #[warning]Project file(s) matching the specified pattern were not found. 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,6 +92,6 @@ steps:
   inputs:
     command: push
     nuGetFeedType: external
-    publishFeedCredentials: '<Name of the NuGet service connection>'
+    publishFeedCredentials: 'pipelines-dotnet-core'
     versioningScheme: byEnvVar
     versionEnvVar: version

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,6 +67,11 @@ steps:
     projects: '**/*Tests/*.csproj'
     arguments: '--configuration $(buildConfiguration) --collect "Code coverage"'
 
+- script: dotnet test dotnetcore-tests --logger trx --collect "Code coverage"
+- task: PublishTestResults@2
+  inputs:
+    testRunner: VSTest
+    testResultsFiles: '**/*.trx'
 
 # .NET Core
 # Restore NuGet packages.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,10 +18,7 @@ steps:
     # You can run any dotnet command in your pipeline. The following example shows how to install and use a .NET global tool, dotnetsay:
     # https://www.nuget.org/packages/dotnetsay/
     dotnet tool install -g dotnetsay
-    # dotnetsay
-
-- script: |
-    dotnetsay
+    dotnet dotnetsay
 
 - task: PublishTestResults@2
   condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,8 @@ steps:
 - script: |
     dotnet build --configuration $(buildConfiguration) # Include additional options such as --configuration to meet your need
     dotnet test dotnetcore-tests --configuration $(buildConfiguration) --logger trx
+    
+    # Publishing the output of the build
     dotnet publish --configuration $(buildConfiguration) --output $BUILD_ARTIFACTSTAGINGDIRECTORY
     # You can run any dotnet command in your pipeline. The following example shows how to install and use a .NET global tool, dotnetsay:
     # https://www.nuget.org/packages/dotnetsay/
@@ -75,3 +77,7 @@ steps:
   inputs:
     testRunner: VSTest
     testResultsFiles: '**/*.trx'
+
+# Package and deliver the code 
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/languages/dotnet-core?view=vsts&tabs=yaml#package-and-deliver-your-code
+- task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ steps:
 
 - task: DotNetCoreInstaller@0
   inputs:
-    version: '2.1.300' # replace this value with the version that you need for your project
+    version: '2.2' # replace this value with the version that you need for your project
 
 # Use the .NET Core task to run unit tests in your .NET Core solution by using testing frameworks like MSTest, xUnit, and NUnit. 
 # THere is a warning # #[warning]Project file(s) matching the specified pattern were not found. 
@@ -51,12 +51,12 @@ steps:
     arguments: '--configuration $(buildConfiguration)'
 
 # Running dotnet tests
-- script: dotnet test dotnetcore-sample.sln --logger trx
-- task: PublishTestResults@2
-  condition: succeededOrFailed()
-  inputs:
-    testRunner: VSTest
-    testResultsFiles: '**/*.trx'
+#- script: dotnet test dotnetcore-sample.sln --logger trx
+#- task: PublishTestResults@2
+#  condition: succeededOrFailed()
+#  inputs:
+#    testRunner: VSTest
+#    testResultsFiles: '**/*.trx'
 
 
 # .NET Core

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ variables:
   buildConfiguration: 'Release'
   imageName: 'dotnetcore:$(Build.BuildId)'
   # define two more variables dockerId and dockerPassword in the build pipeline in UI
-  dockerId: 'possibilITest'
+  dockerId: 'possibilItest'
   dockerPassword: '6Rkdm=LJJZawnpwrMvun6TdAmOSAneAj'
 
 steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,7 @@ steps:
     # https://www.nuget.org/packages/dotnetsay/
     dotnet tool install -g dotnetsay
     # dotnetsay
+- script: dotnetsay
 
 - task: PublishTestResults@2
   condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,9 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core?view=vsts
 
 pool:
-  vmImage: 'Ubuntu 16.04'
+  vmImage: 'ubuntu-16.04' # other options: 'macOS-10.13', 'vs2017-win2016'
+
+
   
 variables:
   buildConfiguration: 'Release'
@@ -12,6 +14,7 @@ steps:
     dotnet build --configuration $(buildConfiguration)
     dotnet test dotnetcore-tests --configuration $(buildConfiguration) --logger trx
     dotnet publish --configuration $(buildConfiguration) --output $BUILD_ARTIFACTSTAGINGDIRECTORY
+    dotnet restore
 
 - task: PublishTestResults@2
   condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ steps:
     #verbosityRestore: 'detailed' # Options: quiet, minimal, normal, detailed, diagnostic
 
 - script: dotnet tool install -g dotnetsay
-- script: dotnetsay
+- script: dotnet dotnetsay
 
 
 - task: PublishTestResults@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -110,9 +110,15 @@ steps:
     arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)'
     zipAfterPublish: True
 
+- task: AzureRmWebAppDeployment@3
+  inputs:
+    azureSubscription: 'Free trial'
+    WebAppName: 'dotnetcore'
+    Package: $(System.ArtifactsDirectory)/**/*.zip
+
 # Build a docker image
-- script: | 
-    docker build -t $(dockerId)/$(imageName) .  # add options to this command to meet your needs 
-    docker build -f Dockerfile -t $(dockerId).azurecr.io/$(imageName) .
-    docker login -u $(dockerId) -p $pswd $(dockerid).azurecr.io
-    docker push $(dockerId).azurecr.io/$(imageName)
+#- script: | 
+#    docker build -t $(dockerId)/$(imageName) .  # add options to this command to meet your needs 
+#    docker build -f Dockerfile -t $(dockerId).azurecr.io/$(imageName) .
+#    docker login -u $(dockerId) -p $pswd $(dockerid).azurecr.io
+#    docker push $(dockerId).azurecr.io/$(imageName)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,9 +16,20 @@ steps:
     dotnet publish --configuration $(buildConfiguration) --output $BUILD_ARTIFACTSTAGINGDIRECTORY
     # You can run any dotnet command in your pipeline. The following example shows how to install and use a .NET global tool, dotnetsay:
     # https://www.nuget.org/packages/dotnetsay/
-    dotnet tool install -g dotnetsay
-    dotnet restore
-    dotnetsay
+    # dotnet tool install -g dotnetsay
+    # dotnetsay    
+
+# .NET Core
+# Restore NuGet packages.
+- task: DotNetCoreCLI@2
+  inputs:
+    command: 'restore'
+    projects: '**/*.csproj'
+    #verbosityRestore: 'detailed' # Options: quiet, minimal, normal, detailed, diagnostic
+
+- script: dotnet tool install -g dotnetsay
+- script: dotnetsay
+
 
 - task: PublishTestResults@2
   condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,12 +51,12 @@ steps:
     arguments: '--configuration $(buildConfiguration)'
 
 # Running dotnet tests
-#- script: dotnet test dotnetcore-sample.sln --logger trx
-#- task: PublishTestResults@2
-#  condition: succeededOrFailed()
-#  inputs:
-#    testRunner: VSTest
-#    testResultsFiles: '**/*.trx'
+#- script: dotnet test dotnetcore-sample.sln --logger trx ya esta arriba
+- task: PublishTestResults@2
+  condition: succeededOrFailed()
+  inputs:
+    testRunner: VSTest
+    testResultsFiles: '**/*.trx'
 
 
 # .NET Core

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,8 +43,18 @@ steps:
 - task: PublishBuildArtifacts@1
 
 # Use the .NET Core task to run unit tests in your .NET Core solution by using testing frameworks like MSTest, xUnit, and NUnit. 
+# THere is a warning # #[warning]Project file(s) matching the specified pattern were not found. 
+# https://stackoverflow.com/a/53053739/2773461
 - task: DotNetCoreCLI@2
   inputs:
     command: test
     projects: '**/*Tests/*.csproj'
     arguments: '--configuration $(buildConfiguration)'
+
+# Running dotnet tests
+- script: dotnet test pipelines-dotnet-core --logger trx
+- task: PublishTestResults@2
+  condition: succeededOrFailed()
+  inputs:
+    testRunner: VSTest
+    testResultsFiles: '**/*.trx'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,11 +14,11 @@ steps:
     dotnet build --configuration $(buildConfiguration) # Include additional options such as --configuration to meet your need
     dotnet test dotnetcore-tests --configuration $(buildConfiguration) --logger trx
     dotnet publish --configuration $(buildConfiguration) --output $BUILD_ARTIFACTSTAGINGDIRECTORY
-    dotnet restore
     # You can run any dotnet command in your pipeline. The following example shows how to install and use a .NET global tool, dotnetsay:
     # https://www.nuget.org/packages/dotnetsay/
     dotnet tool install -g dotnetsay
-    dotnet dotnetsay
+    dotnet restore
+    dotnetsay
 
 - task: PublishTestResults@2
   condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,7 +52,7 @@ steps:
     arguments: '--configuration $(buildConfiguration)'
 
 # Running dotnet tests
-- script: dotnet test pipelines-dotnet-core --logger trx
+- script: dotnet test dotnetcore-sample.sln --logger trx
 - task: PublishTestResults@2
   condition: succeededOrFailed()
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ variables:
   imageName: 'dotnetcore:$(Build.BuildId)'
   # define two more variables dockerId and dockerPassword in the build pipeline in UI
   dockerId: 'dotnetcoretesting'
-  dockerPassword: '/cV0=NHCUvKAY5RSKMMNy0i+Jpm6NaRn'
+  dockerPassword: 'my-password'
 
 
 steps:


### PR DESCRIPTION
In the official guide performing the following in order to install the dotnetsay
```
- script: dotnet tool install -g dotnetsay
- script: dotnetsay
```

This cause the following error when the `CmdLine` task is executed.

```
2019-01-22T10:52:39.3366397Z dotnetsay
2019-01-22T10:52:39.3396264Z [command]/bin/bash --noprofile --norc /home/vsts/work/_temp/cc5e317c-bb83-4b5d-a2ea-7f0374cc4ab9.sh
2019-01-22T10:52:39.3477068Z /home/vsts/work/_temp/cc5e317c-bb83-4b5d-a2ea-7f0374cc4ab9.sh: line 1: dotnetsay: command not found
2019-01-22T10:52:39.3628763Z ##[error]Bash exited with code '127'.
2019-01-22T10:52:39.3643012Z ##[section]Finishing: CmdLine
```

This error was documented by the community [here](https://developercommunity.visualstudio.com/content/problem/340067/install-global-tool.html?childToView=343864#comment-343864) and solved by the same community [of this way](https://github.com/dotnet/cli/issues/8368#issuecomment-424852996):

In the linux version using Ubuntu-16.04 like a vmImage, the azure-pipelines.yml final version is:

```
# Build ASP.NET Core project using Azure Pipelines
# https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core?view=vsts

pool:
  vmImage: 'ubuntu-16.04' # other options: 'macOS-10.13', 'vs2017-win2016'
 
variables:
  buildConfiguration: 'Release'

steps:
- script: |
    dotnet build --configuration $(buildConfiguration) # Include additional options such as --configuration to meet your need
    dotnet test dotnetcore-tests --configuration $(buildConfiguration) --logger trx
    dotnet publish --configuration $(buildConfiguration) --output $BUILD_ARTIFACTSTAGINGDIRECTORY
    dotnet tool install  --tool-path . dotnetsay 
    ./dotnetsay # Executing the command on linux platforms
  displayName: 'Command Line Script'    

# .NET Core
# Restore NuGet packages.
# I am using the restore command to restore packages from a custom feed just in case ..
# But the - script: dotnet restore section code is also valid here.
- task: DotNetCoreCLI@2
  inputs:
    command: 'restore'
    projects: '**/*.csproj'
    #verbosityRestore: 'detailed' # Options: quiet, minimal, normal, detailed, diagnostic

- task: PublishTestResults@2
  condition: succeededOrFailed()
  inputs:
    testRunner: VSTest
    testResultsFiles: '**/*.trx'

- task: PublishBuildArtifacts@1
```

With these changes about installing dotnetsay, the output of my pipeline build finally is:

```
2019-01-22T13:57:06.9150639Z   Installing Microsoft.CodeAnalysis.CSharp 1.3.0.
2019-01-22T13:57:06.9150747Z   Installing System.Net.Security 4.0.1.
2019-01-22T13:57:06.9150803Z   Installing runtime.native.System.Security.Cryptography 4.0.1.
2019-01-22T13:57:27.5054727Z   Restore completed in 22.94 sec for /home/vsts/work/1/s/dotnetcore-sample/dotnetcore-sample.csproj.
2019-01-22T13:57:46.3773656Z   dotnetcore-sample -> /home/vsts/work/1/s/dotnetcore-sample/bin/Release/netcoreapp2.0/dotnetcore-sample.dll
2019-01-22T13:57:47.5945923Z   dotnetcore-tests -> /home/vsts/work/1/s/dotnetcore-tests/bin/Release/netcoreapp2.0/dotnetcore-tests.dll
2019-01-22T13:57:47.6183383Z 
2019-01-22T13:57:47.6184213Z Build succeeded.
2019-01-22T13:57:47.6184487Z     0 Warning(s)
2019-01-22T13:57:47.6184815Z     0 Error(s)
2019-01-22T13:57:47.6185015Z 
2019-01-22T13:57:47.6185268Z Time Elapsed 00:01:25.99
2019-01-22T13:57:49.1897110Z Build started, please wait...
2019-01-22T13:57:49.8069139Z Build completed.
2019-01-22T13:57:49.8069975Z 
2019-01-22T13:57:49.8072260Z Test run for /home/vsts/work/1/s/dotnetcore-tests/bin/Release/netcoreapp2.0/dotnetcore-tests.dll(.NETCoreApp,Version=v2.0)
2019-01-22T13:57:50.2310751Z Microsoft (R) Test Execution Command Line Tool Version 15.9.0
2019-01-22T13:57:50.2311651Z Copyright (c) Microsoft Corporation.  All rights reserved.
2019-01-22T13:57:50.2312065Z 
2019-01-22T13:57:51.0873851Z Starting test execution, please wait...
2019-01-22T13:57:58.4711103Z Results File: /home/vsts/work/1/s/dotnetcore-tests/TestResults/_fv-az558_2019-01-22_13_57_58.trx
2019-01-22T13:57:58.4712969Z 
2019-01-22T13:57:58.4713298Z Total tests: 2. Passed: 2. Failed: 0. Skipped: 0.
2019-01-22T13:57:58.4713638Z Test Run Successful.
2019-01-22T13:57:58.4713804Z Test execution time: 7.1803 Seconds
2019-01-22T13:57:58.8093223Z Microsoft (R) Build Engine version 15.9.20+g88f5fadfbe for .NET Core
2019-01-22T13:57:58.8094122Z Copyright (C) Microsoft Corporation. All rights reserved.
2019-01-22T13:57:58.8094426Z 
2019-01-22T13:57:59.8778042Z   Restore completed in 58.44 ms for /home/vsts/work/1/s/dotnetcore-tests/dotnetcore-tests.csproj.
2019-01-22T13:57:59.8785395Z   Restore completed in 58.38 ms for /home/vsts/work/1/s/dotnetcore-sample/dotnetcore-sample.csproj.
2019-01-22T13:57:59.9144063Z   Restore completed in 29.04 ms for /home/vsts/work/1/s/dotnetcore-sample/dotnetcore-sample.csproj.
2019-01-22T13:58:00.4143426Z   dotnetcore-sample -> /home/vsts/work/1/s/dotnetcore-sample/bin/Release/netcoreapp2.0/dotnetcore-sample.dll
2019-01-22T13:58:01.3892627Z   dotnetcore-sample -> /home/vsts/work/1/a/
2019-01-22T13:58:01.6811700Z   dotnetcore-tests -> /home/vsts/work/1/s/dotnetcore-tests/bin/Release/netcoreapp2.0/dotnetcore-tests.dll
2019-01-22T13:58:02.0939229Z   dotnetcore-tests -> /home/vsts/work/1/a/
2019-01-22T13:58:05.8410371Z You can invoke the tool using the following command: dotnetsay
2019-01-22T13:58:05.8412302Z Tool 'dotnetsay' (version '2.1.4') was successfully installed.
2019-01-22T13:58:12.3940327Z 
2019-01-22T13:58:12.3941390Z         Welcome to using a .NET Core global tool!
2019-01-22T13:58:12.3941592Z     __________________
2019-01-22T13:58:12.3941836Z                       \
2019-01-22T13:58:12.3942198Z                        \
2019-01-22T13:58:12.3942324Z                           ....
2019-01-22T13:58:12.3943069Z                           ....'
2019-01-22T13:58:12.3943208Z                            ....
2019-01-22T13:58:12.3943302Z                         ..........
2019-01-22T13:58:12.3943568Z                     .............'..'..
2019-01-22T13:58:12.3943832Z                  ................'..'.....
2019-01-22T13:58:12.3944277Z                .......'..........'..'..'....
2019-01-22T13:58:12.3944502Z               ........'..........'..'..'.....
2019-01-22T13:58:12.3944774Z              .'....'..'..........'..'.......'.
2019-01-22T13:58:12.3945003Z              .'..................'...   ......
2019-01-22T13:58:12.3945225Z              .  ......'.........         .....
2019-01-22T13:58:12.3945325Z              .                           ......
2019-01-22T13:58:12.3945381Z             ..    .            ..        ......
2019-01-22T13:58:12.3945491Z            ....       .                 .......
2019-01-22T13:58:12.3945547Z            ......  .......          ............
2019-01-22T13:58:12.3945603Z             ................  ......................
2019-01-22T13:58:12.3945879Z             ........................'................
2019-01-22T13:58:12.3946118Z            ......................'..'......    .......
2019-01-22T13:58:12.3947428Z         .........................'..'.....       .......
2019-01-22T13:58:12.3947704Z      ........    ..'.............'..'....      ..........
2019-01-22T13:58:12.3947997Z    ..'..'...      ...............'.......      ..........
2019-01-22T13:58:12.3948267Z   ...'......     ...... ..........  ......         .......
2019-01-22T13:58:12.3948335Z  ...........   .......              ........        ......
2019-01-22T13:58:12.3948629Z .......        '...'.'.              '.'.'.'         ....
2019-01-22T13:58:12.3948862Z .......       .....'..               ..'.....
2019-01-22T13:58:12.3949333Z    ..       ..........               ..'........
2019-01-22T13:58:12.3949400Z           ............               ..............
2019-01-22T13:58:12.3949638Z          .............               '..............
2019-01-22T13:58:12.3949925Z         ...........'..              .'.'............
2019-01-22T13:58:12.3950164Z        ...............              .'.'.............
2019-01-22T13:58:12.3950464Z       .............'..               ..'..'...........
2019-01-22T13:58:12.3950824Z       ...............                 .'..............
2019-01-22T13:58:12.3951029Z        .........                        ..............
2019-01-22T13:58:12.3951086Z         .....
2019-01-22T13:58:12.3951120Z 
2019-01-22T13:58:12.4199569Z ##[section]Finishing: Command Line Script
```